### PR TITLE
Standardize local storage and preset

### DIFF
--- a/www/js/EventsCtrl.js
+++ b/www/js/EventsCtrl.js
@@ -13,8 +13,10 @@ angular.module('awhere.controllers')
   $scope.events = testEvents;
   $scope.categories = testCategories;
 
-  $scope.currentPreset = Preset.getCurrent();
-  console.log($scope.currentPreset);
+  $scope.$on('$ionicView.beforeEnter', function() {
+    $scope.currentPreset = Preset.getCurrent();
+    console.log($scope.currentPreset);
+  }
 
   $scope.toggleView = function(state) {
     $scope.viewState = state;

--- a/www/js/EventsCtrl.js
+++ b/www/js/EventsCtrl.js
@@ -16,7 +16,7 @@ angular.module('awhere.controllers')
   $scope.$on('$ionicView.beforeEnter', function() {
     $scope.currentPreset = Preset.getCurrent();
     console.log($scope.currentPreset);
-  }
+  });
 
   $scope.toggleView = function(state) {
     $scope.viewState = state;

--- a/www/js/EventsCtrl.js
+++ b/www/js/EventsCtrl.js
@@ -13,7 +13,7 @@ angular.module('awhere.controllers')
   $scope.events = testEvents;
   $scope.categories = testCategories;
 
-  $scope.currentPreset = Preset.find(JSON.parse(localStorage.getItem('currPreset')));
+  $scope.currentPreset = Preset.getCurrent();
   console.log($scope.currentPreset);
 
   $scope.toggleView = function(state) {
@@ -34,9 +34,9 @@ angular.module('awhere.controllers')
 
       for (var i = 0; i < $scope.currentPreset.interests.length; i++){
         $scope.category = $scope.currentPreset.interests[i];
-        if (event['title'] === "Segal Seminar Series: John Bielenberg"){
-          console.log(event['primary category'], $scope.category);
-        }
+        // if (event['title'] === "Segal Seminar Series: John Bielenberg"){
+        //   console.log(event['primary category'], $scope.category);
+        // }
 
         if ([event['primary category'], event['secondary category'], event['3rd category']].indexOf($scope.category) > -1) {
           if (event['price'].indexOf("Free") != -1 || parseInt(event['price']) <= parseInt($scope.currentPreset.price)) {

--- a/www/js/Preset.js
+++ b/www/js/Preset.js
@@ -2,6 +2,7 @@ angular.module('awhere.services')
 
 .factory('Preset', function() {
   var presets = JSON.parse(localStorage.getItem('presets'));
+  var currentPreset = JSON.parse(localStorage.getItem('currPreset'))
   console.log(presets);
 
   if (!presets)
@@ -9,6 +10,7 @@ angular.module('awhere.services')
 
   var updateLocalStorage = function() {
     localStorage.setItem('presets', JSON.stringify(presets));
+    localStorage.setItem('currPreset', JSON.stringify(currentPreset));
   };
 
   return {
@@ -51,6 +53,19 @@ angular.module('awhere.services')
           return;
         }
       } 
+    },
+    getCurrent: function(){
+      for(var i=0; i<presets.length; i++){
+        if(presets[i].id === currentPreset){
+          return presets[i];
+        }
+        console.log("Panic! Current preset not found (Is it null?)");
+      };
+      return null;
+    },
+    setCurrent: function(id){
+      currentPreset = id;
+      updateLocalStorage();
     }
   };
 });


### PR DESCRIPTION
Preset and Events controllers will now use Preset service to get current preset instead of going through local storage manually (abstraction).

Also, load current preset using before enter callback.
